### PR TITLE
Migrate redirects from staging.bsky.app to bsky.app

### DIFF
--- a/main.py
+++ b/main.py
@@ -88,8 +88,6 @@ def generate_html_with_image(full_path):
     except:
         pass
 
-    post_url = full_path.replace("bsky.app","staging.bsky.app")
-
     record = post_content.get("record")
     text = record.get("text")
 
@@ -162,8 +160,6 @@ def generate_html_textonly(full_path):
 
     img_url = None
 
-    post_url = full_path.replace("bsky.app","staging.bsky.app")
-
     record = post_content.get("record")
     text = record.get("text")
 
@@ -207,8 +203,6 @@ def generate_html_qrt(full_path):
     author = post_content.get("author")
 
     img_url = None 
-
-    post_url = full_path.replace("bsky.app","staging.bsky.app")
 
     record = post_content.get("record")
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,15 +18,15 @@ class TestFoo(unittest.TestCase):
         # fails if error
     
     def test_is_profile_url(self):
-        url = "https://staging.bsky.app/profile/klatz.co"
-        url2 = "https://staging.bsky.app/profile/klatz.co/"
-        url3 = "https://staging.bsky.app/profile/klatz.co/post/lol"
+        url = "https://bsky.app/profile/klatz.co"
+        url2 = "https://bsky.app/profile/klatz.co/"
+        url3 = "https://bsky.app/profile/klatz.co/post/lol"
         assert is_just_profile_url(url) == True
         assert is_just_profile_url(url2) == True
         assert is_just_profile_url(url3) == False
     
     def test_generate_profile_html(self):
-        url = "https://staging.bsky.app/profile/klatz.co"
+        url = "https://bsky.app/profile/klatz.co"
         generate_html_profileonly(url)
     
     def test1(self):


### PR DESCRIPTION
Noticed psky.app previews were still redirecting to staging.bsky.app. Let's migrate to bsky.app since the web app is now in production on that domain!